### PR TITLE
Make populate_async doesn't require Pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ async fn populate_seeds() -> Result<()> {
 
     seeder
         .populate_async("fixtures/users.yml", |input| {
-            Box::pin(async move { User::insert(&input).await })
+            async move { User::insert(&input).await }
         })
         .await?;
 
@@ -212,13 +212,13 @@ async fn populate_seeds() -> Result<()> {
     // Seeder stores mapping of companies record label and its id
     seeder
         .populate_async("companies.yml", |input| {
-            Box::pin(async move { Company::insert(&input).await })
+            async move { Company::insert(&input).await }
         })
         .await?;
     // the mapping is used to resolve the reference tags
     seeder
         .populate_async("users.yml", |input| {
-            Box::pin(async move { User::insert(&input).await })
+            async move { User::insert(&input).await }
         })
         .await?;
 

--- a/tests/database_seeder_async.rs
+++ b/tests/database_seeder_async.rs
@@ -28,7 +28,7 @@ async fn test_database_seeder_populate_async_items() -> Result<()> {
     let ids = seeder
         .populate_async("items.yml", |input: Item| {
             let mut mock_table = mock_table.clone();
-            Box::pin(async move { mock_table.insert(input).await })
+            async move { mock_table.insert(input).await }
         })
         .await?;
 
@@ -64,7 +64,7 @@ async fn test_database_seeder_populate_async_customers() -> Result<()> {
     let ids = seeder
         .populate_async("customers.yml", |input: Customer| {
             let mut mock_table = mock_table.clone();
-            Box::pin(async move { mock_table.insert(input).await })
+            async move { mock_table.insert(input).await }
         })
         .await?;
 
@@ -117,7 +117,7 @@ async fn test_database_seeder_populate_async_orders() -> Result<()> {
         let results = seeder
             .populate_async("orders.yml", |input: Order| {
                 let mut mock_orders_table = mock_orders_table.clone();
-                Box::pin(async move { mock_orders_table.insert(input).await })
+                async move { mock_orders_table.insert(input).await }
             })
             .await;
 
@@ -135,7 +135,7 @@ async fn test_database_seeder_populate_async_orders() -> Result<()> {
         seeder
             .populate_async("items.yml", |input: Item| {
                 let mut mock_items_table = mock_items_table.clone();
-                Box::pin(async move { mock_items_table.insert(input).await })
+                async move { mock_items_table.insert(input).await }
             })
             .await?;
         let mock_customers_table = MockTable::<Customer>::new(vec![
@@ -146,7 +146,7 @@ async fn test_database_seeder_populate_async_orders() -> Result<()> {
         seeder
             .populate_async("customers.yml", |input: Customer| {
                 let mut mock_customers_table = mock_customers_table.clone();
-                Box::pin(async move { mock_customers_table.insert(input).await })
+                async move { mock_customers_table.insert(input).await }
             })
             .await?;
 
@@ -159,7 +159,7 @@ async fn test_database_seeder_populate_async_orders() -> Result<()> {
         let ids = seeder
             .populate_async("orders.yml", |input: Order| {
                 let mut mock_orders_table = mock_orders_table.clone();
-                Box::pin(async move { mock_orders_table.insert(input).await })
+                async move { mock_orders_table.insert(input).await }
             })
             .await?;
 


### PR DESCRIPTION
When I'm seeing a sample code
```rust
seeder
        .populate_async("fixtures/users.yml", |input| {
            Box::pin(async move { User::insert(&input).await })
        })
        .await?;
```
It's good if we can remove `Box::pin`.
And I tweaked the type parameters in `populate_async` and I've succeeded to pass tests without `Box::pin`.

I still have no idea what is the root cause of why we needed `Pin` but it seems to work at least for tests.
Thanks!