### PR TITLE
Added support for uuid

### DIFF
--- a/src/database_seeder.rs
+++ b/src/database_seeder.rs
@@ -115,10 +115,11 @@ impl DatabaseSeeder {
     ///     Ok(())
     /// }
     /// ```
-    pub fn populate<F, T>(&mut self, filename: &str, mut loader: F) -> Result<Vec<i64>>
+    pub fn populate<F, T, U>(&mut self, filename: &str, mut loader: F) -> Result<Vec<U>>
     where
-        F: FnMut(T) -> Result<i64>,
+        F: FnMut(T) -> Result<U>,
         T: DeserializeOwned,
+        U: ToString
     {
         let named_records = load_named_records::<T>(filename, &self.base_dir, &self.name_resolver)?;
         let mut ids = Vec::new();
@@ -168,15 +169,16 @@ impl DatabaseSeeder {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn populate_async<Fut, F, T>(
+    pub async fn populate_async<Fut, F, T, U>(
         &mut self,
         filename: &str,
         mut loader: F,
-    ) -> Result<Vec<i64>>
+    ) -> Result<Vec<U>>
     where
-        Fut: Future<Output = Result<i64>>,
+        Fut: Future<Output = Result<U>>,
         F: FnMut(T) -> Fut,
         T: DeserializeOwned,
+        U: ToString
     {
         let named_records = load_named_records::<T>(filename, &self.base_dir, &self.name_resolver)?;
         self.filenames.push(filename.to_string());

--- a/src/database_seeder.rs
+++ b/src/database_seeder.rs
@@ -119,7 +119,7 @@ impl DatabaseSeeder {
     where
         F: FnMut(T) -> Result<U>,
         T: DeserializeOwned,
-        U: ToString
+        U: ToString,
     {
         let named_records = load_named_records::<T>(filename, &self.base_dir, &self.name_resolver)?;
         let mut ids = Vec::new();
@@ -178,7 +178,7 @@ impl DatabaseSeeder {
         Fut: Future<Output = Result<U>>,
         F: FnMut(T) -> Fut,
         T: DeserializeOwned,
-        U: ToString
+        U: ToString,
     {
         let named_records = load_named_records::<T>(filename, &self.base_dir, &self.name_resolver)?;
         self.filenames.push(filename.to_string());

--- a/tests/test_utils/mock_database.rs
+++ b/tests/test_utils/mock_database.rs
@@ -7,10 +7,7 @@ use std::sync::{Arc, Mutex};
 
 // async insertion is done in random order, so records has to be sorted before testing
 pub fn sort_records_by_ids<T>(records: Vec<T>, ids: Vec<i64>) -> Vec<T> {
-    let mut indexed_records = ids
-        .iter()
-        .zip(records.into_iter())
-        .collect::<Vec<(&i64, T)>>();
+    let mut indexed_records = ids.iter().zip(records).collect::<Vec<(&i64, T)>>();
     indexed_records.sort_unstable_by_key(|(i, _)| *i);
     indexed_records
         .into_iter()
@@ -34,7 +31,7 @@ where
     T: Clone,
 {
     pub fn new(ids_by_name: Vec<(String, i64)>) -> Self {
-        let ids_by_name = HashMap::from_iter(ids_by_name.into_iter());
+        let ids_by_name = HashMap::from_iter(ids_by_name);
 
         MockTable {
             ids_by_name: Arc::new(Mutex::new(ids_by_name)),


### PR DESCRIPTION
Added generic return type in 'populate' funcs for support primary keys other than u64 (uuid).
