### PR TITLE
workaround: temporarily allow unused_imports warnings with tests

### DIFF
--- a/tests/database_seeder.rs
+++ b/tests/database_seeder.rs
@@ -1,5 +1,7 @@
 mod test_utils;
-use test_utils::*;
+use test_utils::{
+    get_test_base_dir, parse_datetime, sort_records_by_ids, Customer, Item, MockTable, Order, Plan,
+};
 extern crate cder;
 
 use anyhow::Result;

--- a/tests/database_seeder_async.rs
+++ b/tests/database_seeder_async.rs
@@ -1,5 +1,7 @@
 mod test_utils;
-use test_utils::*;
+use test_utils::{
+    get_test_base_dir, parse_datetime, sort_records_by_ids, Customer, Item, MockTable, Order, Plan,
+};
 extern crate cder;
 
 use anyhow::Result;

--- a/tests/struct_loader.rs
+++ b/tests/struct_loader.rs
@@ -1,5 +1,5 @@
 mod test_utils;
-use test_utils::*;
+use test_utils::{get_test_base_dir, parse_datetime, Customer, Item, Order, Plan};
 extern crate cder;
 
 use anyhow::Result;

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -1,6 +1,11 @@
 mod mock_database;
 mod types;
+
+// FIXME: workaround for false positive detection of unused_imports, which might be related to:
+// https://github.com/rust-lang/rust/issues/121708
+#[allow(unused_imports)]
 pub use mock_database::{sort_records_by_ids, MockTable};
+
 pub use types::{Customer, Item, Order, Plan};
 
 use anyhow::Result;


### PR DESCRIPTION
PR #10 failed because of lint errors that recently appeared. (thank you @mtshr for pointing this out!)

From what I understand it is false positive detection (possibly related to https://github.com/rust-lang/rust/issues/121708 ??) with latest rustc, but I might be missing something.

@kenkoooo san, please let me know if you have any insights on this 🙏 