### PR TITLE
feat: impl `IntoIterator`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ regex = "1.7"
 once_cell = "1.16"
 
 [dev-dependencies]
+assert_unordered = "0.3.5"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.23", features = ["time", "rt-multi-thread", "macros"] }

--- a/src/struct_loader.rs
+++ b/src/struct_loader.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use serde::de::DeserializeOwned;
 
-use std::iter;
 use crate::{load_named_records, Dict};
+use std::iter;
 
 /// StructLoader deserializes struct instances from specified file.
 /// To resolve embedded tags, you need to provide HashMap that indicates corresponding records to

--- a/src/struct_loader.rs
+++ b/src/struct_loader.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use serde::de::DeserializeOwned;
 
+use std::iter;
 use crate::{load_named_records, Dict};
 
 /// StructLoader deserializes struct instances from specified file.
@@ -57,6 +58,21 @@ where
     pub filename: String,
     pub base_dir: String,
     named_records: Option<Dict<T>>,
+}
+
+impl<'a, T> IntoIterator for &'a StructLoader<T>
+where
+    T: DeserializeOwned,
+{
+    type Item = (&'a String, &'a T);
+    type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.named_records.as_ref() {
+            Some(records) => Box::new(records.iter()),
+            None => Box::new(iter::empty()),
+        }
+    }
 }
 
 impl<T> StructLoader<T>


### PR DESCRIPTION
# Improve StructLoader usability by implementing `IntoIterator` trait

This PR implemented the `IntoIterator` trait for `StructLoader<T>`. 
This enhancement allows direct use of standard iteration features on `StructLoader` instances.

## Key Benefits

- Direct use of for loops
  - You can now use for loops directly on StructLoader instances.
- Use of iterator method chains
  - You can now directly chain iterator methods like into_iter(), filter(), map(), etc.
  
## Usage Example

```rust
use serde::Deserialize;

#[derive(Deserialize, Clone, Debug)]
struct User {
    name: String,
    email: String,
}

fn load_user(label: &str) -> Result<()> {
    let mut loader = StructLoader::<User>::new("users.yml", "fixtures");
    let result = loader.load(&Dict::<String>::new())?;
    
    // Example using a for loop
    for (key, value) in result {
        println!("key: {}, value: {:?}", key, value);
    }

    // Example using iterator method chaining
    result.into_iter()
        .filter(|(key, _)| *key == label)
        .for_each(|(key, value)| {
            println!("key: {}, value: {:?}", key, value);
        });

    Ok(())
}
```