### PR TITLE
refactor: how to build path in reader

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,12 +3,11 @@ use std::{env, fs, path::PathBuf};
 
 /// Read seeds from specified file
 pub fn read_file(filename: &str, base_dir: &str) -> Result<String> {
-    let mut path = PathBuf::new();
-    if let Ok(current_base) = env::var("CARGO_MANIFEST_DIR") {
-        path.push(current_base)
-    }
-    path.push(base_dir);
-    path.push(filename);
+    let path = env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_default()
+        .join(base_dir)
+        .join(filename);
 
     fs::read_to_string(&path)
         .map_err(|err| anyhow::anyhow!("Can't open the file: {:?}\n   err: {}", path, err))


### PR DESCRIPTION
# Improve and Simplify Path Construction Logic

This PR enhances and simplifies the path construction logic in the `build_path` function.

- Utilized `unwrap_or_default()` for concise fallback handling when the environment variable is not present.
- Employed the `join` method for efficient concatenation of the base directory and filename.
