### PR TITLE
test against rust stable/nightly versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: [1.68, stable]
+        version: [1.68.0, stable]
     name: Test with Rust ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,6 +24,10 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
           components: rustfmt, clippy
+      # tokio 1.39+ requires rust <= 1.70.0
+      # https://github.com/tokio-rs/tokio?tab=readme-ov-file#supported-rust-versions
+      - run: cargo update -p tokio --precise 1.38.1
+        if: matrix.version == '1.68.0'
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features
       - run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,6 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
           components: rustfmt, clippy
-      # tokio 1.39+ requires rust <= 1.70.0
-      # https://github.com/tokio-rs/tokio?tab=readme-ov-file#supported-rust-versions
-      - run: cargo update -p tokio --precise 1.38.1
-        if: matrix.version == '1.68.0'
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features
       - run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ once_cell = "1.16"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.23", features = ["time", "rt-multi-thread", "macros"] }
+tokio = { version = "=1.38", features = ["time", "rt-multi-thread", "macros"] }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::{collections::HashMap, env, usize};
+use std::{collections::HashMap, env};
 
 macro_rules! regex {
     ($re:literal $(,)?) => {{


### PR DESCRIPTION
Our CI used to fix a (relatively old) version of rust to test against in order to make sure this crate can be used with any newer versions, but it causes sudden failure of CI when dependencies are updated, which is not nice to new contributors especially.

This PR is to test against the latest stable version, plus nightly only (Testing nightly may seem too much, so we could omit them if CI frequently fails)